### PR TITLE
게임 맵 최단 거리 문제 풀이

### DIFF
--- a/session1/bfs/gayeong/ShortestGameMap.java
+++ b/session1/bfs/gayeong/ShortestGameMap.java
@@ -1,0 +1,47 @@
+package bfs.gayeong;
+
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class ShortestGameMap {
+    private static final int[] dx = {1, -1, 0, 0};
+    private static final int[] dy = {0, 0, 1, -1};
+    private static int[][] visited;
+    private static Queue<Position> pq;
+
+    public int solution(int[][] maps) {
+        int n = maps.length;
+        int m = maps[0].length;
+
+        pq = new LinkedList<>();
+        visited = new int[n][m];
+
+        pq.offer(new Position(0, 0));
+        visited[0][0] = 1;
+
+        while(!pq.isEmpty()) {
+            Position now = pq.poll();
+            for (int i = 0; i < 4; i++) {
+                int nx = now.x + dx[i];
+                int ny = now.y + dy[i];
+
+                if (nx >= 0 && nx < n && ny >= 0 && ny < m && visited[nx][ny] == 0 && maps[nx][ny] != 0) {
+                    pq.offer(new Position(nx, ny));
+                    visited[nx][ny] = visited[now.x][now.y] + 1;
+                }
+            }
+
+        }
+        return visited[n - 1][m - 1] == 0 ? -1 : visited[n - 1][m - 1];
+    }
+}
+
+class Position {
+    int x;
+    int y;
+
+    public Position(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+}


### PR DESCRIPTION
### BFS를 선택한 이유
가장 짧은 거리를 구하는 것이기 때문에 모든 경우의 수를 탐색하는 dfs보다 bfs를 선택하는 것이 적절하다고 생각했습니다.

### 풀이 과정
1. 시작 노드를 큐에 넣는다.
2. 시작 노드로부터 상하좌우 방향으로 갈 수 있는 노드를 탐색한다.
3. visited는 해당 노드까지 도달하는 데 걸린 비용을 나타낸다.
4. 이미 방문한 노드는 탐색하지 않는다. 왜냐하면 이미 최단 거리이기 때문이다.
5. 방문할 수 있는 모든 노드를 탐색하면 종료한다.
6. 도착해야 하는 노드의 비용을 출력한다.

