### PR TITLE
여행 경로 문제 풀이

### DIFF
--- a/session1/dfs/gayeong/TravelRoute.java
+++ b/session1/dfs/gayeong/TravelRoute.java
@@ -1,0 +1,48 @@
+package dfs.gayeong;
+
+import java.util.*;
+
+public class TravelRoute {
+    private List<String[]> routes;
+    private String[][] tickets;
+    private boolean[] used;
+
+    public String[] solution(String[][] tickets) {
+        this.tickets = tickets;
+        this.used = new boolean[tickets.length + 1];
+
+        routes = new ArrayList<>();
+
+        String[] route = new String[tickets.length];
+        route[0] = "ICN";
+
+        dfs("ICN", route, 0);
+
+        routes.sort((a, b) -> {
+            for (int i = 0; i < a.length; i++) {
+                int temp = a[i].compareTo(b[i]);
+                if (temp != 0) return temp;
+            }
+            return 0;
+        });
+
+        return routes.get(0);
+    }
+
+    private void dfs(String current, String[] route, int depth) {
+        route[depth] = current;
+        if (depth == tickets.length) {
+            routes.add(Arrays.copyOf(route, route.length));
+            return;
+        }
+
+        for (int i = 0; i < tickets.length; i++) {
+            if (!used[i] && current.equals(tickets[i][0])) {
+                used[i] = true;
+                dfs(tickets[i][1], route, depth + 1);
+                used[i] = false;
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
### ✅ DFS 선택 이유
모든 경우의 수를 탐색해야 하므로 DFS를 사용했습니다.

---

### ✅ 풀이 과정

1. 주어진 항공권을 모두 사용하여 `"ICN"`에서 출발하는 여행 경로를 찾습니다.
2. DFS를 통해 가능한 모든 경로를 탐색하며, 각 티켓은 한 번씩만 사용하도록 `used[]` 배열로 관리합니다.
3. 경로는 `String[]`으로 구성하며, 완성된 경로는 리스트에 저장한 뒤, 사전순으로 정렬하여 가장 앞선 경로를 반환합니다.

---

### ✅ 백트래킹을 사용한 이유

처음에 백트래킹 없이 DFS만 사용했을 때는 테스트 케이스 1번만 통과하고,  
다음과 같은 케이스에서 오답이 발생했습니다:

#### 테스트 케이스

- **입력값**  
  `[["ICN", "SFO"], ["ICN", "ATL"], ["SFO", "ATL"], ["ATL", "ICN"], ["ATL", "SFO"]]`

- **기댓값**  
  `["ICN", "ATL", "ICN", "SFO", "ATL", "SFO"]`

- **실행 결과**  
  `["ICN", "SFO", "ATL", "ICN", "ATL", "SFO"]`

이 문제에서 `"ICN"`에서 출발 가능한 항공권이 `"SFO"`와 `"ATL"` 두 장 존재하는데,  
사전순으로는 `"ATL"`이 `"SFO"`보다 앞섭니다.  
따라서 정답 경로를 구하려면 `"ICN → ATL"`을 먼저 시도해야 합니다.

하지만 DFS가 `"ICN → SFO"` 경로를 먼저 선택하면,  
이후 티켓을 모두 사용한 경로가 만들어지면서 탐색이 종료되고,  
사전순으로 더 앞선 `"ICN → ATL"` 경로는 **탐색 대상조차 되지 못합니다.**

이러한 경우를 방지하려면, **한 경로를 탐색한 후 반드시 상태를 되돌려 다른 선택지도 모두 탐색**할 수 있어야 합니다.  
→ 이 과정에서 **백트래킹이 필수적**입니다.

---
### ✅ 깊은 복사를 해야 하는 이유

DFS 탐색 중 사용하는 `route` 배열은 재귀적으로 호출될 때마다 계속해서 값이 바뀝니다.  
이 상태에서 `routes.add(route)`처럼 그대로 참조를 추가하면,  
**모든 경로가 동일한 배열 인스턴스를 참조하게 되어 나중에 덮어쓰기 문제가 발생**합니다.

#### ❌ 잘못된 예 (얕은 복사)

```java
routes.add(route);  // DFS 중 route가 변경되면서 모든 경로가 덮어씌워짐
```
#### ✅ 올바른 예 (깊은 복사)
```java
routes.add(Arrays.copyOf(route, route.length));  // 배열의 현재 상태를 복사해서 저장
```
