### PR TITLE
전력망을 둘로 나누기 문제 풀이

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="VcsDirectoryMappings" defaultProject="true" />
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
 </project>

--- a/session1/bfs/gayeong/ElectricityDivider.java
+++ b/session1/bfs/gayeong/ElectricityDivider.java
@@ -1,0 +1,80 @@
+package bfs.gayeong;
+
+import java.util.*;
+
+public class ElectricityDivider {
+    private ArrayList<Integer>[] trees;
+    int n;
+
+    public int solution(int n, int[][] wires) {
+        this.n = n;
+
+        trees  = new ArrayList[n + 1];
+        for (int i = 0; i < n + 1; i++) {
+            trees[i] = new ArrayList<>();
+        }
+
+        for (int[] wire : wires) {
+            trees[wire[0]].add(wire[1]);
+            trees[wire[1]].add(wire[0]);
+        }
+
+        int result = Integer.MAX_VALUE;
+
+        for (int[] wire : wires) {
+
+            trees[wire[0]].remove(Integer.valueOf(wire[1]));
+            trees[wire[1]].remove(Integer.valueOf(wire[0]));
+
+            int diff = Math.abs(n - 2 * countWire(1));
+
+            result = Math.min(result, diff);
+
+            trees[wire[0]].add(wire[1]);
+            trees[wire[1]].add(wire[0]);
+        }
+
+        return result;
+    }
+
+    private int countWire(int start) {
+        boolean[] visited = new boolean[n + 1];
+        Queue<Integer> queue = new LinkedList<>();
+        queue.offer(start);
+        visited[start] = true;
+        int count = 0;
+
+        while(!queue.isEmpty()) {
+            int current = queue.poll();
+            count++;
+
+            for (int next : trees[current]) {
+                if (!visited[next]) {
+                    queue.offer(next);
+                    visited[next] = true;
+                }
+            }
+        }
+
+        return count;
+    }
+
+    public static void main(String[] args) {
+        int[][] wires = {
+                {1, 3},
+                {2, 3},
+                {3, 4},
+                {4, 5},
+                {4, 6},
+                {4, 7},
+                {7, 8},
+                {7, 9}
+        };
+
+        ElectricityDivider ed = new ElectricityDivider();
+
+        int result = ed.solution(9, wires);
+
+        System.out.println(result);
+    }
+}

--- a/session1/session1.iml
+++ b/session1/session1.iml
@@ -3,6 +3,7 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
     </content>
     <orderEntry type="inheritedJdk" />


### PR DESCRIPTION

### ✅ BFS를 선택한 이유
DFS로도 해결할 수 있지만,  평소 BFS 구현을 많이 해서 사용하였습니다.

---

### 🧭 풀이 과정

1. 모든 전선을 하나씩 끊어보며 시뮬레이션합니다.
2. 전선을 끊을 때마다 그래프를 수정하고,  
   끊긴 그래프에서 **BFS 또는 DFS를 통해 한쪽 전력망의 노드 개수**를 셉니다.
3. 전체 노드 개수 `n`에서 해당 개수를 빼서 나머지 전력망의 크기를 구한 뒤,  
   두 전력망의 **개수 차이의 절댓값을 구합니다.**
4. 모든 경우 중 **차이가 가장 적은 값**을 정답으로 반환합니다.