### PR TITLE
전력망 둘로 나누기 (프로그래머스 - 86971), 타겟넘버 (프로그래머스 - 43165), 네트워크 (프로그래머스 - 43162)

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="corretto-11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="VcsDirectoryMappings" defaultProject="true" />
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
 </project>

--- a/session1/bfs/chaeyeon/ShortestGameMap.java
+++ b/session1/bfs/chaeyeon/ShortestGameMap.java
@@ -1,0 +1,49 @@
+import java.util.*;
+
+class Solution {
+    static int[] dx = {-1, 1, 0, 0};
+    static int[] dy = {0, 0, -1, 1};
+
+    static class Point{
+        int x,y, distance;
+
+        Point(int x, int y, int distance){
+            this.x=x;
+            this.y=y;
+            this.distance=distance;
+
+        }
+    }
+
+    public int solution(int[][] maps) {
+        int n = maps.length;
+        int m = maps[0].length;
+        int[][] visited = new int[n][m];
+
+        Queue<Point> queue = new LinkedList<>();
+        queue.offer(new Point(0,0,1));
+        visited[0][0] = 1;
+
+        while(!queue.isEmpty()){
+            Point current = queue.poll();
+
+            if (current.x ==n-1 && current.y == m-1){
+                return current.distance;
+            }
+
+            for(int i=0; i<4;i++){
+                int nx = current.x + dx[i];
+                int ny = current.y + dy[i];
+
+                if(nx>=0 && nx<n && ny>=0 && ny<m){
+                    if(maps[nx][ny] == 1 && visited[nx][ny] == 0){
+                        visited[nx][ny] = current.distance+1;
+                        queue.offer(new Point(nx,ny,current.distance+1));
+                    }
+                }
+            }
+        }
+        return -1;
+
+    }
+}

--- a/session1/bfs/chaeyeon/ShortestGameMap.java
+++ b/session1/bfs/chaeyeon/ShortestGameMap.java
@@ -44,6 +44,5 @@ class Solution {
             }
         }
         return -1;
-
     }
 }

--- a/session1/dfs/chaeyeon/ElectricityDivider.java
+++ b/session1/dfs/chaeyeon/ElectricityDivider.java
@@ -1,0 +1,51 @@
+import java.util.*;
+
+class Solution {
+    static ArrayList<Integer>[] graph;
+    static boolean[] visited;
+
+    public int solution(int n, int[][] wires) {
+        int answer = Integer.MAX_VALUE;
+        graph = new ArrayList[n+1];
+        for(int i=1;i<=n;i++){
+            graph[i] = new ArrayList<>();
+        }
+
+        //연결하기
+        for(int[] wire : wires){
+            graph[wire[0]].add(wire[1]);
+            graph[wire[1]].add(wire[0]);
+        }
+
+        for(int[] wire:wires){
+            visited = new boolean[n+1];
+
+            int a = wire[0];
+            int b = wire[1];
+            graph[a].remove(Integer.valueOf(b));
+            graph[b].remove(Integer.valueOf(a));
+
+            int cnt = dfs(1); //1번 노드에서 시작이기에
+
+            int diff = Math.abs(cnt-(n-cnt));
+            answer = Math.min(answer,diff);
+
+            graph[a].add(b);
+            graph[b].add(a);
+        }
+
+        return answer;
+    }
+
+    static int dfs(int node){
+        visited[node] = true;
+        int cnt = 1;
+
+        for(int next : graph[node]){
+            if(!visited[next]){
+                cnt+=dfs(next);
+            }
+        }
+        return cnt;
+    }
+}

--- a/session1/dfs/chaeyeon/Network.java
+++ b/session1/dfs/chaeyeon/Network.java
@@ -1,24 +1,25 @@
 class Solution {
     static int cnt = 0;
+    static boolean[] visited;
 
     public int solution(int n, int[][] computers) {
-        boolean[] visited = new boolean[n];
+        visited = new boolean[n];
 
-        for (int i=0; i<n;i++){
-            if(!visited[i]){
-                dfs(n, computers, visited, i);
+        for (int i = 0; i < n; i++) {
+            if (!visited[i]) {
+                dfs(n, computers, i);
                 cnt++;
             }
         }
         return cnt;
     }
 
-    public void dfs(int n, int[][] computers, boolean[] visited, int current){
+    public void dfs(int n, int[][] computers, int current) {
         visited[current] = true;
 
-        for(int i=0;i<n;i++){
-            if (computers[current][i] == 1 && !visited[i]){
-                dfs(n, computers, visited, i);
+        for (int i = 0; i < n; i++) {
+            if (computers[current][i] == 1 && !visited[i]) {
+                dfs(n, computers, i);
             }
         }
     }

--- a/session1/dfs/chaeyeon/Network.java
+++ b/session1/dfs/chaeyeon/Network.java
@@ -1,0 +1,25 @@
+class Solution {
+    static int cnt = 0;
+
+    public int solution(int n, int[][] computers) {
+        boolean[] visited = new boolean[n];
+
+        for (int i=0; i<n;i++){
+            if(!visited[i]){
+                dfs(n, computers, visited, i);
+                cnt++;
+            }
+        }
+        return cnt;
+    }
+
+    public void dfs(int n, int[][] computers, boolean[] visited, int current){
+        visited[current] = true;
+
+        for(int i=0;i<n;i++){
+            if (computers[current][i] == 1 && !visited[i]){
+                dfs(n, computers, visited, i);
+            }
+        }
+    }
+}

--- a/session1/dfs/chaeyeon/TargetNumber.java
+++ b/session1/dfs/chaeyeon/TargetNumber.java
@@ -1,0 +1,20 @@
+class Solution {
+    static int cnt = 0;
+
+    public int solution(int[] numbers, int target) {
+        dfs(numbers,target,0,0);
+        return cnt;
+    }
+
+    public void dfs(int[] numbers, int target, int depth, int sum){
+        if(depth == numbers.length){
+            if (sum == target){
+                cnt++;
+            }
+            return;
+        }
+        dfs(numbers,target,depth+1,sum+numbers[depth]);
+        dfs(numbers,target,depth+1,sum-numbers[depth]);
+
+    }
+}


### PR DESCRIPTION
### 전력망 둘로 나누기 (프로그래머스 - 86971) 

➡️**알고리즘**
각 선로를 끊었을 때 두 그룹으로 나뉜 송전탑의 수를 구하기 위해 재귀적으로 연결된 노드를 탐색하는데 DFS알고리즘이 적합하다고 생각하여 DFS 사용

➡️**문제풀이**
- 그래프를 구성하여 각 송전탑과 선로들을 양방향으로 연결
- 각 선로를 끊고, DFS를 통해 한 그룹의 송전탑 수를 구한다. (->다음 탐색을 위해 끊은 후 복구해 놓음)
- 두 그룹의 송전탑 수 차이를 구하고 그 중에서도 최소 차이를 찾는다.

</br>

### 타겟넘버 (프로그래머스 - 43165)
➡️**알고리즘**
+와 - 에 대해서 모든 경우의 수를 탐색해야 하기에 DFS 알고리즘 사용

➡️**문제풀이**
- DFS를 이용해 숫자의 각 위치에서 더하거나 빼는 두 가지 선택을 재귀적으로 탐색
- 깊이가 배열의 길이에 도달하면 현재 합이 목표값과 일치하는지 확인
- 일치하면 CNT값 증가

</br>

### 네트워크 (프로그래머스 - 43162)
➡️**알고리즘**
연결된 컴퓨터들을 하나의 네트워크 단위로 파악하기 위해 DFS 알고리즘 사용

➡️**문제풀이**
- 1번 노드에서 시작하여 1번과 직접 또는 간접적으로 연결되어 있으면서 방문하지 않은 모든 노드에 대해 DFS로 탐색 및 방문 처리 진행
- DFS가 종료되었다는 것은 하나의 네트워크에 속한 모든 컴퓨터를 방문했다는 의미이므로, cnt += 1 
- 이후에도 아직 방문하지 않은 노드가 있다면, 그 노드를 새로운 시작점으로 삼아 DFS를 다시 수행
- 이 과정을 반복하면서 DFS 탐색을 시작한 횟수가 네트워크의 수 즉 결과값이 된다.