### PR TITLE
단어 변환 문제 풀이

### DIFF
--- a/session1/bfs/gayeong/ChangeWord.java
+++ b/session1/bfs/gayeong/ChangeWord.java
@@ -1,0 +1,58 @@
+package bfs.gayeong;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Queue;
+
+public class ChangeWord {
+    private Map<String, Integer> visited;
+    private String[] words;
+    private String begin;
+    private String target;
+
+    public void init (String begin, String target, String[] words) {
+        this.begin = begin;
+        this.target = target;
+        this.words = words;
+        this.visited = new HashMap<>();
+    }
+
+    public int solution(String begin, String target, String[] words) {
+        init(begin, target, words);
+
+        bfs();
+
+        int result = visited.getOrDefault(target, 0);
+
+        return result == 0 ? 0 : result - 1;
+    }
+
+    private void bfs() {
+        Queue<String> queue = new LinkedList<>();
+        queue.offer(begin);
+        visited.put(begin, 1);
+
+        while (!queue.isEmpty()) {
+            String current = queue.poll();
+            if (current.equals(target)) break;
+
+            for (String next : words) {
+                if (visited.getOrDefault(next, 0) == 0 && possible(current, next)) {
+                    queue.offer(next);
+                    visited.put(next, visited.get(current) + 1);
+                }
+            }
+        }
+    }
+
+    private boolean possible(String word1, String word2) {
+        int count = 0;
+        for (int i = 0; i < word1.length(); i++) {
+            if (word1.charAt(i) != word2.charAt(i)) count++;
+        }
+
+        if (count == 1) return true;
+        return false;
+    }
+}


### PR DESCRIPTION
### BFS 선택 이유
단어 변환이 가능한 경우만 탐색해야 하기 때문에 BFS를 사용했습니다.

### 풀이 과정
기존 BFS는 방문 여부만 확인한다면, 이번에는 변환 가능 여부도 확인해야 하기 때문에 possible 함수를 만들어 사용했습니다.