### PR TITLE
벽 부수고 이동하기 (백준 - 2206)

### DIFF
--- a/session1/bfs/chaeyeon/CrushWall.java
+++ b/session1/bfs/chaeyeon/CrushWall.java
@@ -1,0 +1,74 @@
+package bfs.chaeyeon;
+import java.util.*;
+
+public class CrushWall {
+
+    static int N,M;
+    static int[][] map;
+    static boolean[][][] visited;
+    static int[] dx={-1,1,0,0};
+    static int[] dy = {0,0,-1,1};
+
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        N = sc.nextInt();
+        M = sc.nextInt();
+
+        map=new int[N][M];
+        visited = new boolean[N][M][2];
+
+        for(int i=0;i<N;i++){
+            String row = sc.next();
+            for(int j=0;j<M;j++){
+                map[i][j] = row.charAt(j) - '0';
+            }
+        }
+        int result = bfs();
+        System.out.println(result);
+    }
+
+    static class Node{
+        int x,y,distance, crush;
+        Node(int x, int y, int distance, int crush){
+            this.x=x;
+            this.y=y;
+            this.distance=distance;
+            this.crush=crush;
+        }
+    }
+
+    static int bfs(){
+        Queue<Node> queue = new LinkedList<>();
+        queue.offer(new Node(0,0,1,0));
+        visited[0][0][0] = true; 
+        
+        while(!queue.isEmpty()){
+            Node current = queue.poll();
+            if(current.x == N-1 && current.y ==M-1){
+                return current.distance;
+            }
+            
+            for(int dir=0;dir<4;dir++){
+                int nx = current.x+dx[dir];
+                int ny = current.y+dy[dir];
+                
+                if(nx<0 || nx>=N || ny<0 || ny>=M){
+                    continue;
+                }
+                
+                //-> 다음 위치가 빈칸일 경우
+                if(map[nx][ny] == 0 && !visited[nx][ny][current.crush]){
+                    visited[nx][ny][current.crush] = true;
+                    queue.offer(new Node(nx,ny, current.distance+1, current.crush));
+                }
+
+                //->다음 위치가 벽이고 한번도 부수지 않은 상태일 경우
+                if(map[nx][ny]==1 && current.crush==0 &&!visited[nx][ny][1]){
+                    visited[nx][ny][1] = true;
+                    queue.offer(new Node(nx,ny, current.distance+1,1));
+                }
+            }
+        }
+        return -1;
+    }
+}


### PR DESCRIPTION
➡️**알고리즘**
- 최단경로를 구하는 문제이기에 BFS 알고리즘을 활용

➡️**문제풀이**
- 해당 문제의 포인트는 "벽을 한번 부술 수 있다"라는 조건이다.
- 해당 조건을 만족하기 위해 Node 클래스에 crush라는 상태 변수를 추가하여, 각 좌표에 대해 벽을 부쉈는지 여부를 함께 기록
- 동일한 위치라도 벽을 부쉈을 때와 부수지 않았을 때를 구분하여 각각의 방문 여부를 관리해야 하기에 visited[x][y][crush] 형태의 3차원 배열을 사용했다.
1. visited[x][y][0] → 벽을 부수지 않고 해당 칸에 방문
2. visited[x][y][1] → 벽을 한 번 부수고 해당 칸에 방문
- BFS를 통해 상하좌우 이동하며 탐색을 진행했고,
1. 다음 칸이 빈칸인 0 이고 아직 해당 칸을 방문하지 않았다면 큐에 추가
2. 다음칸이 벽인 1이고 아직 벽을 부수지 않았다면 벽을 부수고 큐에 추가
