### PR TITLE
벽 부수고 이동하기

### DIFF
--- a/session1/bfs/gayeong/BreakWallAndMove.java
+++ b/session1/bfs/gayeong/BreakWallAndMove.java
@@ -10,55 +10,57 @@ public class BreakWallAndMove {
     static int[] dx = {1, -1, 0, 0};
     static int[] dy = {0, 0, -1, 1};
     static int n, m;
-    static int[][] visited;
+    static int[][][] visited;
     static int[][] map;
     static int result = Integer.MAX_VALUE;
 
     public int solution(int[][] map) {
-        map = map;
         n = map.length;
         m = map[0].length;
 
-        breakWall();
+        move();
 
         return result;
     }
 
-    private void breakWall() {
-        for (int i = 0; i < n; i++) {
-            for (int j = 0; j < m; j++) {
-                if (map[i][j] == 1) {
-                    map[i][j] = 0;
-                    result = Math.min(result, move());
-                    map[i][j] = 1;
-                }
-            }
-        }
-    }
-
     private int move() {
         Queue<Node> queue = new LinkedList<>();
-        visited = new int[n][m];
+        visited = new int[n][m][2];
 
-        queue.offer(new Node(0, 0));
-        visited[0][0] = 1;
+        queue.offer(new Node(0, 0, 0));
+        visited[0][0][0] = 1;
 
         while (!queue.isEmpty()) {
             Node current = queue.poll();
+            int x = current.x;
+            int y = current.y;
+            int broken = current.broken;
 
             for (int i = 0; i < 4; i++) {
-                int nx = current.x + dx[i];
-                int ny = current.y + dy[i];
+                int nx = x + dx[i];
+                int ny = y + dy[i];
 
-                if (nx >= 0 && nx < n && ny >= 0 && ny < m && visited[nx][ny] == 0 && map[nx][ny] == 0) {
-                    queue.offer(new Node(nx ,ny));
-                    visited[nx][ny] = visited[current.x][current.y] + 1;
+                if (nx < 0 || nx >= n || ny < 0 || ny >= m) continue;
+
+                if (map[nx][ny] == 0 && visited[nx][ny][broken] == 0) {
+                    visited[nx][ny][broken] = visited[x][y][broken] + 1;
+                    queue.offer(new Node(nx, ny, broken));
+                }
+
+                if (map[nx][ny] == 1 && broken == 0 && visited[nx][ny][1] == 0) {
+                    visited[nx][ny][1] = visited[x][y][broken] + 1;
+                    queue.offer(new Node(nx, ny, 1));
                 }
             }
         }
 
-        int dist = visited[n - 1][m - 1];
-        return (dist == 0 ? Integer.MAX_VALUE : dist);
+        int noBreak = visited[n-1][m-1][0];
+        int didBreak = visited[n-1][m-1][1];
+
+        if (noBreak == 0) noBreak = Integer.MAX_VALUE;
+        if (didBreak == 0) didBreak = Integer.MAX_VALUE;
+
+        return Math.min(noBreak, didBreak);
     }
 
     public static void main(String[] args) throws IOException {
@@ -87,9 +89,11 @@ public class BreakWallAndMove {
 class Node {
     int x;
     int y;
+    int broken;
 
-    public Node(int x, int y) {
+    public Node(int x, int y, int broken) {
         this.x = x;
         this.y = y;
+        this.broken =  broken;
     }
 }

--- a/session1/bfs/gayeong/BreakWallAndMove.java
+++ b/session1/bfs/gayeong/BreakWallAndMove.java
@@ -1,0 +1,95 @@
+package bfs.gayeong;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class BreakWallAndMove {
+    static int[] dx = {1, -1, 0, 0};
+    static int[] dy = {0, 0, -1, 1};
+    static int n, m;
+    static int[][] visited;
+    static int[][] map;
+    static int result = Integer.MAX_VALUE;
+
+    public int solution(int[][] map) {
+        map = map;
+        n = map.length;
+        m = map[0].length;
+
+        breakWall();
+
+        return result;
+    }
+
+    private void breakWall() {
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < m; j++) {
+                if (map[i][j] == 1) {
+                    map[i][j] = 0;
+                    result = Math.min(result, move());
+                    map[i][j] = 1;
+                }
+            }
+        }
+    }
+
+    private int move() {
+        Queue<Node> queue = new LinkedList<>();
+        visited = new int[n][m];
+
+        queue.offer(new Node(0, 0));
+        visited[0][0] = 1;
+
+        while (!queue.isEmpty()) {
+            Node current = queue.poll();
+
+            for (int i = 0; i < 4; i++) {
+                int nx = current.x + dx[i];
+                int ny = current.y + dy[i];
+
+                if (nx >= 0 && nx < n && ny >= 0 && ny < m && visited[nx][ny] == 0 && map[nx][ny] == 0) {
+                    queue.offer(new Node(nx ,ny));
+                    visited[nx][ny] = visited[current.x][current.y] + 1;
+                }
+            }
+        }
+
+        int dist = visited[n - 1][m - 1];
+        return (dist == 0 ? Integer.MAX_VALUE : dist);
+    }
+
+    public static void main(String[] args) throws IOException {
+        BreakWallAndMove bwa = new BreakWallAndMove();
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        String[] nm = br.readLine().split(" ");
+        int n = Integer.parseInt(nm[0]);
+        int m = Integer.parseInt(nm[1]);
+
+        int[][] map = new int[n][m];
+
+        for (int i = 0; i < n; i++) {
+            char[] line = br.readLine().toCharArray();
+            for (int j = 0; j < m; j++) {
+                map[i][j] = line[j] - '0';
+            }
+        }
+
+        int result = bwa.solution(map);
+        System.out.println(result);
+    }
+}
+
+class Node {
+    int x;
+    int y;
+
+    public Node(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+}


### PR DESCRIPTION
## 🐞 문제 상황 
- 기존 구현:  
  - `breakWall()` 메서드로 **모든 벽(1) 하나씩 부숴가며** 매번 `move()`(BFS)를 호출  
  - 최악의 경우 BFS를 `O(NM)`번 반복 ⇒ 전체 복잡도 O((NM)×(NM)) = O((NM)²)  
  - N, M 최대 1,000일 때 시간초과 발생

---

## 💡 해결 접근
1. **벽 부수기 상태를 BFS 상태로 포함**  
   - `(x, y, broken)` 3차원 상태로 관리  
   - `broken`=0: 아직 벽을 부수지 않은 경로  
   - `broken`=1: 이미 벽을 한 번 부순 경로  
2. **한 번의 BFS**  
   - 빈 칸 이동 시 → 동일한 `broken` 상태로  
   - 벽 만났을 때 `broken=0` 이면 → `broken=1` 상태로 이동  
   - `visited[x][y][0/1]` 에 거리 기록  
3. **최종 거리 계산**  
   - `visited[n-1][m-1][0]` vs `visited[n-1][m-1][1]` 중 작은 값 사용  
   - 도달 불가(0)인 쪽은 `∞`로 간주해 무시