### PR TITLE
안전영역 문제 풀이

### DIFF
--- a/session1/bfs/gayeong/SafeArea.java
+++ b/session1/bfs/gayeong/SafeArea.java
@@ -1,0 +1,74 @@
+package bfs.gayeong;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class SafeArea {
+    static int n;
+    static int[][] graph;
+    static boolean[][] visited;
+    static int[] dx = {1, -1, 0, 0};
+    static int[] dy = {0, 0, 1, -1};
+
+    static class Node {
+        int x, y;
+        public Node(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        n = Integer.parseInt(br.readLine());
+        graph = new int[n][n];
+
+        for (int i = 0; i < n; i++) {
+            String[] line = br.readLine().split(" ");
+            for (int j = 0; j < n; j++) {
+                graph[i][j] = Integer.parseInt(line[j]);
+            }
+        }
+
+        int result = 0;
+        for (int height = 0; height <= 100; height++) {
+            int temp = 0;
+            visited = new boolean[n][n];
+            for (int i = 0; i < n; i++) {
+                for (int j = 0; j < n; j++) {
+                    if (visited[i][j] || graph[i][j] <= height) continue;
+
+                    bfs(i, j, height);
+                    temp++;
+                }
+            }
+            result = Math.max(result, temp);
+        }
+
+
+        System.out.println(result);
+    }
+
+    static void bfs(int x, int y, int height) {
+        Queue<Node> queue = new LinkedList<>();
+        queue.offer(new Node(x, y));
+        visited[x][y] = true;
+
+        while (!queue.isEmpty()) {
+            Node current = queue.poll();
+            for (int i = 0; i < 4; i++) {
+                int nx = current.x + dx[i];
+                int ny = current.y + dy[i];
+
+                if (nx >= 0 && nx < n && ny >= 0 && ny < n && !visited[nx][ny] && graph[nx][ny] > height) {
+                    queue.offer(new Node(nx, ny));
+                    visited[nx][ny] = true;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### BFS 사용 이유
특정 노드에서 주변 노드를 탐색해나가야 하기 때문에 사용했습니다.

### 풀이 과정
1. `height`를 0부터 100까지 반복  
2. 각 높이에 대해 새로운 `visited` 배열 초기화  
3. 모든 칸을 순회하며, 아직 방문하지 않았고 `graph[i][j] > height`인 칸을 만나면 안전 영역 시작 지점으로 간주
4. 탐색이 끝난 후 안전 영역의 값을 갱신  