### PR TITLE
숨바꼭질3 문제 풀이

### DIFF
--- a/session1/bfs/gayeong/HideAndSeek3.java
+++ b/session1/bfs/gayeong/HideAndSeek3.java
@@ -1,0 +1,66 @@
+package bfs.gayeong;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.PriorityQueue;
+
+public class HideAndSeek3 {
+    static int n, k;
+    static int[] visited;
+    static final int MAX_LENGTH = 100001;
+
+    static class Node {
+        int idx, dist;
+        public Node(int idx, int dist) {
+            this.idx = idx;
+            this.dist = dist;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String[] nk = br.readLine().split(" ");
+        n = Integer.parseInt(nk[0]);
+        k = Integer.parseInt(nk[1]);
+
+        visited = new int[MAX_LENGTH];
+        Arrays.fill(visited, Integer.MAX_VALUE);
+
+        bfs();
+
+        System.out.println(visited[k]);
+    }
+
+    static void bfs() {
+        PriorityQueue<Node> pq = new PriorityQueue<>((a, b) -> a.dist - b.dist);
+        visited[n] = 0;
+        pq.offer(new Node(n, 0));
+
+        while (!pq.isEmpty()) {
+            Node cur = pq.poll();
+            if (cur.dist > visited[cur.idx]) continue;
+
+            // 순간이동: 비용 0
+            int nxt = cur.idx * 2;
+            if (nxt < MAX_LENGTH && cur.dist < visited[nxt]) {
+                visited[nxt] = cur.dist;
+                pq.offer(new Node(nxt, cur.dist));
+            }
+
+            // 앞으로/뒤로: 비용 1
+            nxt = cur.idx + 1;
+            if (nxt < MAX_LENGTH && cur.dist + 1 < visited[nxt]) {
+                visited[nxt] = cur.dist + 1;
+                pq.offer(new Node(nxt, cur.dist + 1));
+            }
+
+            nxt = cur.idx - 1;
+            if (nxt >= 0 && cur.dist + 1 < visited[nxt]) {
+                visited[nxt] = cur.dist + 1;
+                pq.offer(new Node(nxt, cur.dist + 1));
+            }
+        }
+    }
+}


### PR DESCRIPTION
### BFS 사용 이유
탐색 시 DFS 보다 BFS가 더 적은 시간이 들기 때문에 사용했습니다.

### 풀이 과정
하나의 정점에 대해서 3가지의 경우 중 최적 경로를 탐색해야 합니다.
BFS는 먼저 탐색되는 경로가 최소 비용이 되기 때문에 탐색 순서를 제어한다면 최적 경로를 탐색할 수 있습니다.
자바에선 우선순위큐를 이용해 구현할 수 있으며, 정렬 기준은 람다함수로 작성하여 현재 정점의 가중치를 기준으로 정렬하도록 작성했습니다.