### PR TITLE
 거의 최단 경로 (백준 - 5719)

### DIFF
--- a/session1/bellmanFord/chaeyeon/Worries.java
+++ b/session1/bellmanFord/chaeyeon/Worries.java
@@ -17,8 +17,8 @@ public class Worries {
     static int N, start, end, M;
     static List<Edge> edges = new ArrayList<>();
     static long[] dist;
-    static boolean[] reachable;
-    static int[] earn;
+    static boolean[] visited;
+    static int[] money;
 
     public static void main(String[] args) {
         Scanner sc = new Scanner(System.in);
@@ -28,9 +28,6 @@ public class Worries {
         end = sc.nextInt();
         M = sc.nextInt();
 
-        dist = new long[N];
-        earn = new int[N];
-
         for (int i = 0; i < M; i++) {
             int from = sc.nextInt();
             int to = sc.nextInt();
@@ -38,65 +35,55 @@ public class Worries {
             edges.add(new Edge(from, to, cost));
         }
 
-        for (int i = 0; i < N; i++) {
-            earn[i] = sc.nextInt();
-            dist[i] = NEG_INF;
+        money  = new int[N];
+        for(int i=0; i<N;i++){
+            money[i] = sc.nextInt();
         }
 
-        dist[start] = earn[start];
+        dist = new long[N];
+        Arrays.fill(dist,NEG_INF);
+        dist[start] = money[start];
 
-        // 벨만 포드
+
+
         for (int i = 0; i < N - 1; i++) {
             for (Edge edge : edges) {
-                if (dist[edge.from] == NEG_INF) continue;
-                if (dist[edge.to] < dist[edge.from] - edge.cost + earn[edge.to]) {
-                    dist[edge.to] = dist[edge.from] - edge.cost + earn[edge.to];
+                if (dist[edge.from] == NEG_INF)
+                    continue;
+                if (dist[edge.to] < dist[edge.from] - edge.cost + money[edge.to]) {
+                    dist[edge.to] = dist[edge.from] - edge.cost + money[edge.to];
                 }
             }
         }
 
-        // 양의 사이클 탐지
-        boolean infinite = false;
-        for (int i = 0; i < N; i++) {
-            for (Edge edge : edges) {
-                if (dist[edge.from] == NEG_INF) continue;
-                if (dist[edge.to] < dist[edge.from] - edge.cost + earn[edge.to]) {
-                    if (isReachable(edge.to, end)) {
-                        infinite = true;
-                        break;
-                    }
+        for (Edge edge : edges) {
+            if (dist[edge.from] == NEG_INF)
+                continue;
+            if (dist[edge.to] < dist[edge.from] - edge.cost + money[edge.to]) {
+                visited = new boolean[N];
+                dfs(edge.to);
+                if (visited[end]) {
+                    System.out.println("Gee");
+                    return;
                 }
             }
-            if (infinite) break;
         }
+
 
         if (dist[end] == NEG_INF) {
             System.out.println("gg");
-        } else if (infinite) {
-            System.out.println("Gee");
-        } else {
+        }
+        else {
             System.out.println(dist[end]);
         }
     }
-
-    static boolean isReachable(int from, int target) {
-        boolean[] visited = new boolean[N];
-        Queue<Integer> q = new LinkedList<>();
-        q.offer(from);
-        visited[from] = true;
-
-        while (!q.isEmpty()) {
-            int curr = q.poll();
-            if (curr == target) return true;
-
-            for (Edge edge : edges) {
-                if (edge.from == curr && !visited[edge.to]) {
-                    visited[edge.to] = true;
-                    q.offer(edge.to);
-                }
+    static void dfs(int node){
+        visited[node] = true;
+        for(Edge edge : edges){
+            if(edge.from == node && !visited[edge.to]){
+                dfs(edge.to);
             }
         }
 
-        return false;
     }
 }

--- a/session1/bellmanFord/chaeyeon/Worries.java
+++ b/session1/bellmanFord/chaeyeon/Worries.java
@@ -1,0 +1,102 @@
+package bellmanFord.chaeyeon;
+
+import java.util.*;
+
+public class Worries {
+
+    static class Edge{
+        int from,to,cost;
+        Edge(int from, int to, int cost){
+            this.from =from;
+            this.to = to;
+            this.cost = cost;
+        }
+    }
+
+    static final long NEG_INF = Long.MIN_VALUE;
+    static int N, start, end, M;
+    static List<Edge> edges = new ArrayList<>();
+    static long[] dist;
+    static boolean[] reachable;
+    static int[] earn;
+
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+
+        N = sc.nextInt();
+        start = sc.nextInt();
+        end = sc.nextInt();
+        M = sc.nextInt();
+
+        dist = new long[N];
+        earn = new int[N];
+
+        for (int i = 0; i < M; i++) {
+            int from = sc.nextInt();
+            int to = sc.nextInt();
+            int cost = sc.nextInt();
+            edges.add(new Edge(from, to, cost));
+        }
+
+        for (int i = 0; i < N; i++) {
+            earn[i] = sc.nextInt();
+            dist[i] = NEG_INF;
+        }
+
+        dist[start] = earn[start];
+
+        // 벨만 포드
+        for (int i = 0; i < N - 1; i++) {
+            for (Edge edge : edges) {
+                if (dist[edge.from] == NEG_INF) continue;
+                if (dist[edge.to] < dist[edge.from] - edge.cost + earn[edge.to]) {
+                    dist[edge.to] = dist[edge.from] - edge.cost + earn[edge.to];
+                }
+            }
+        }
+
+        // 양의 사이클 탐지
+        boolean infinite = false;
+        for (int i = 0; i < N; i++) {
+            for (Edge edge : edges) {
+                if (dist[edge.from] == NEG_INF) continue;
+                if (dist[edge.to] < dist[edge.from] - edge.cost + earn[edge.to]) {
+                    if (isReachable(edge.to, end)) {
+                        infinite = true;
+                        break;
+                    }
+                }
+            }
+            if (infinite) break;
+        }
+
+        if (dist[end] == NEG_INF) {
+            System.out.println("gg");
+        } else if (infinite) {
+            System.out.println("Gee");
+        } else {
+            System.out.println(dist[end]);
+        }
+    }
+
+    static boolean isReachable(int from, int target) {
+        boolean[] visited = new boolean[N];
+        Queue<Integer> q = new LinkedList<>();
+        q.offer(from);
+        visited[from] = true;
+
+        while (!q.isEmpty()) {
+            int curr = q.poll();
+            if (curr == target) return true;
+
+            for (Edge edge : edges) {
+                if (edge.from == curr && !visited[edge.to]) {
+                    visited[edge.to] = true;
+                    q.offer(edge.to);
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/session1/dijkstra/chaeyeon/AlmostShortest.java
+++ b/session1/dijkstra/chaeyeon/AlmostShortest.java
@@ -1,0 +1,104 @@
+package dijkstra.chaeyeon;
+
+import java.util.*;
+
+public class AlmostShortest {
+
+    static class Node{
+        int to;
+        int cost;
+        public Node(int to, int cost){
+            this.to = to;
+            this.cost = cost;
+        }
+    }
+
+    static int n,m,s,d;
+    static List<Node>[] graph;
+    static List<Integer>[] prevNodes;
+    static int[] dist;
+
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+
+        while (true) {
+            n = sc.nextInt();
+            m = sc.nextInt();
+            if (n == 0 && m == 0)
+                break;
+
+            s = sc.nextInt();
+            d = sc.nextInt();
+            graph = new ArrayList[n];
+            prevNodes = new ArrayList[n];
+
+            for (int i = 0; i < n; i++) {
+                graph[i] = new ArrayList<>();
+                prevNodes[i] = new ArrayList<>();
+            }
+
+            for (int i = 0; i < m; i++) {
+                int u = sc.nextInt();
+                int v = sc.nextInt();
+                int p = sc.nextInt();
+                graph[u].add(new Node(v, p));
+            }
+
+
+            dijkstra(s,graph,prevNodes); // 최단 경로 구함
+            removeShortestPath(d);
+            dist = dijkstra(s, graph, null); //2번째 최단 경로 구함
+            System.out.println(dist[d] == Integer.MAX_VALUE ? -1 : dist[d]);
+
+
+        }
+    }
+    static int[] dijkstra(int start, List<Node>[] graph, List<Integer>[] prevNodes) {
+        int n = graph.length;
+        dist = new int[n];
+        Arrays.fill(dist, Integer.MAX_VALUE);
+        dist[start] = 0;
+
+        PriorityQueue<Node> pq = new PriorityQueue<>(Comparator.comparing(node->node.cost));
+        pq.offer(new Node(start,0));
+
+        while ((!pq.isEmpty())){
+            Node current = pq.poll();
+            if (current.cost > dist[current.to])
+                continue;
+
+            for(Node next : graph[current.to]){
+                int newCost = dist[current.to]+next.cost;
+                if(newCost < dist[next.to]){
+                    dist[next.to] = newCost;
+                    pq.offer(new Node(next.to, newCost));
+                    if(prevNodes != null){
+                        prevNodes[next.to].clear();
+                        prevNodes[next.to].add(current.to);
+                    }
+                }
+                else if(newCost == dist[next.to] && prevNodes !=null){
+                    prevNodes[next.to].add(current.to);
+                }
+            }
+        }
+        return dist;
+    }
+
+    static void removeShortestPath(int end){
+        Queue<Integer> queue = new LinkedList<>();
+        queue.offer(end);
+        boolean[][] visited = new boolean[n][n];
+
+        while(!queue.isEmpty()){
+            int current = queue.poll();
+            for(int prev : prevNodes[current]){
+                if(!visited[prev][current]){
+                    visited[prev][current] = true;
+                    graph[prev].removeIf(node -> node.to == current);
+                    queue.offer(prev);
+                }
+            }
+        }
+    }
+}

--- a/session1/dijkstra/chaeyeon/FurthestNode.java
+++ b/session1/dijkstra/chaeyeon/FurthestNode.java
@@ -1,0 +1,65 @@
+package dijkstra.chaeyeon;
+
+import java.util.*;
+
+class FurthestNode {
+    public int solution(int n, int[][] edge) {
+        List<List<Integer>> graph = new ArrayList<>();
+
+        for(int i=0; i<=n; i++){
+            graph.add(new ArrayList<>());
+        }
+
+        for(int[] e : edge){
+            graph.get(e[0]).add(e[1]);
+            graph.get(e[1]).add(e[0]);
+        }
+
+        int[] distance = dijkstra(n,graph);
+
+        int maxResult = 0;
+        for(int i=1;i<=n;i++){
+            if(distance[i] != Integer.MAX_VALUE){
+                maxResult = Math.max(maxResult, distance[i]);
+            }
+        }
+
+        int cnt = 0;
+        for (int i=1; i<=n;i++){
+            if(distance[i] == maxResult){
+                cnt++;
+            }
+        }
+
+        return cnt;
+    }
+
+    private int[] dijkstra(int n, List<List<Integer>> graph) {
+        int[] distance = new int[n+1];
+        Arrays.fill(distance, Integer.MAX_VALUE);
+        distance[1] = 0;
+
+        PriorityQueue<int[]> pq = new PriorityQueue<>(Comparator.comparingInt(a -> a[1]));
+        pq.offer(new int[]{1,0});
+
+
+        while(!pq.isEmpty()){
+            int[] current = pq.poll();
+            int node = current[0];
+            int dist = current[1];
+
+            if(dist > distance[node])
+                continue;
+
+            for(int next : graph.get(node)){
+                if(distance[next] > dist+1){
+                    distance[next] = dist+1;
+                    pq.offer(new int[]{next, dist+1});
+                }
+            }
+        }
+        return distance;
+
+    }
+
+}

--- a/session1/dijkstra/chaeyeon/Party.java
+++ b/session1/dijkstra/chaeyeon/Party.java
@@ -1,0 +1,92 @@
+package dijkstra.chaeyeon;
+
+import java.util.*;
+
+public class Party {
+
+    static class Node{
+        int to;
+        int time;
+        public Node(int to, int time){
+            this.to = to;
+            this.time = time;
+        }
+    }
+
+    static int n,m,x;
+    static List<Node>[] graph;
+    static int[] distFromX, distToX;
+
+
+
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        n = sc.nextInt();
+        m = sc.nextInt();
+        x = sc.nextInt();
+
+        graph = new ArrayList[n+1];
+        for (int i=1; i<=n; i++){
+            graph[i] = new ArrayList<>();
+        }
+
+        for(int i=0; i<m; i++){
+            int from = sc.nextInt();
+            int to  = sc.nextInt();
+            int time = sc.nextInt();
+            graph[from].add(new Node(to, time));
+        }
+
+
+        distFromX = dijkstra(x,graph);
+
+        //양방향이 아니기에
+        List<Node>[] reverseGraph = new ArrayList[n+1];
+        for(int i=1;i<=n;i++){
+            reverseGraph[i] = new ArrayList<>();
+        }
+        for(int from = 1; from<=n;from++){
+            for(Node node : graph[from]){
+                reverseGraph[node.to].add(new Node(from, node.time));
+            }
+        }
+
+        distToX = dijkstra(x,reverseGraph);
+
+        int result = 0;
+        for (int i=1; i<=n; i++){
+            int cnt = distFromX[i] +distToX[i];
+            result = Math.max(result, cnt);
+        }
+
+        System.out.println(result);
+
+
+
+
+
+    }
+
+    static int[] dijkstra(int start, List<Node>[] graph){
+        int[] dist = new int[n+1];
+        Arrays.fill(dist, Integer.MAX_VALUE);
+        dist[start] = 0;
+
+        PriorityQueue<Node> pq = new PriorityQueue<>(Comparator.comparing(n->n.time));
+        pq.offer(new Node(start,0));
+
+        while(!pq.isEmpty()){
+            Node current = pq.poll();
+
+            if(current.time > dist[current.to])
+                continue;
+            for(Node n :graph[current.to]){
+                if(dist[n.to] > dist[current.to] + n.time){
+                    dist[n.to] = dist[current.to] + n.time;
+                    pq.offer(new Node(n.to, dist[n.to]));
+                }
+            }
+        }
+        return dist;
+    }
+}


### PR DESCRIPTION
➡️**알고리즘**
- 다익스트라 알고리즘을 두 번 사용
1. 첫 번째 다익스트라로 최단 경로의 거리를 구하고 최단 경로에 포함된 간선들을 역추적하여 제거
2. 두 번째 다익스트라로 최단 경로에 포함되지 않은 도로만을 사용한 거의 최단 경로를 구한다.

➡️**문제풀이**
- 문제는 '절대로 최단 경로를 찾아주지 않고, 항상 거의 최단 경로(두 번째로 짧은 경로)를 찾아주는 네비게이션'을 구현하는 것
- 거의 최단 경로란 최단 경로에 포함된 간선을 모두 제거한 후, 그 다음에 나오는 최단 경로를 의미
- 따라서 먼저 다익스트라를 통해 최단 거리를 계산하고, 최단 경로를 역추적하여 해당 경로의 간선들을 제거
- 간선이 제거된 그래프에서 다시 다익스트라를 실행해 거의 최단 경로를 구하고 그런 경로가 없을 경우 -1 출력
