### PR TITLE
N-Queen문제 풀이

### DIFF
--- a/session1/src/week3/backtracking/gayeong/NQueen.java
+++ b/session1/src/week3/backtracking/gayeong/NQueen.java
@@ -1,0 +1,45 @@
+package week3.backtracking.gayeong;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.IOException;
+
+public class NQueen {
+    static int N;
+    static int[] board;
+    static int count = 0;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        board = new int[N];
+        dfs(0);
+        System.out.println(count);
+    }
+
+    static void dfs(int row) {
+        if (row == N) {
+            count++;
+            return;
+        }
+
+        for (int col = 0; col < N; col++) {
+            board[row] = col;
+            if (isValid(row)) {
+                dfs(row + 1);
+            }
+        }
+    }
+
+    static boolean isValid(int row) {
+        for (int i = 0; i < row; i++) {
+            // 퀸은 칸의 수에 상관없이, 한 방향으로 쭉 움직일 수 있다.
+            // 가로, 세로, 대각선으로 모두 움직일 수 있다.
+            // 같은 열이거나, 대각선에 위치해 있는 경우
+            if (board[i] == board[row] || Math.abs(row - i) == Math.abs(board[row] - board[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
### 알고리즘
각 행마다 퀸을 하나씩 배치하는 조합 문제로, DFS + 백트래킹을 사용했습니다.

### 문제풀이
문제에 들어가기 앞서 체스룰을 잘 몰라서 찾아봤습니다. 
퀸은 다음과 같이 움직일 수 있습니다.
- 퀸은 칸 수 제한 없이 가로, 세로, 대각선 방향으로 이동할 수 있습니다.
- 따라서 퀸끼리는 같은 행, 열, 대각선에 함께 존재할 수 없습니다.

1. 각 행(row)에 대해 열(col)을 순회하며 퀸을 둘 수 있는 위치를 찾습니다.
2. board[i]는 i번째 행에 놓은 퀸의 열 위치를 의미합니다.
3. 퀸을 놓으려는 위치가 이전 퀸들과 같은 열이거나 대각선에 위치하면 탐색을 중단합니다.
4. N개의 퀸을 모두 배치한 경우(row == N), 유효한 해로 간주하여 결과값을 1 증가시킵니다.

