### PR TITLE
feat: 배열 돌리기 문제 풀이

### DIFF
--- a/session1/src/week4/simulation/gayeong/TurnArray.java
+++ b/session1/src/week4/simulation/gayeong/TurnArray.java
@@ -1,0 +1,109 @@
+package week4.simulation.gayeong;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class TurnArray {
+    static int N, M, K;
+    static int[][] origin;
+    static int[][] rotateInfo;
+    static boolean[] visited;
+    static int answer = Integer.MAX_VALUE;
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+
+        origin = new int[N][M];
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < M; j++) {
+                origin[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        rotateInfo = new int[K][3];
+        for (int i = 0; i < K; i++) {
+            st = new StringTokenizer(br.readLine());
+            rotateInfo[i][0] = Integer.parseInt(st.nextToken());
+            rotateInfo[i][1] = Integer.parseInt(st.nextToken());
+            rotateInfo[i][2] = Integer.parseInt(st.nextToken());
+        }
+
+        visited = new boolean[K];
+        dfs(0, new ArrayList<>());
+        System.out.println(answer);
+    }
+
+    // 회전 순열 만들기
+    static void dfs(int depth, List<Integer> sequence) {
+        if (depth == K) {
+            int[][] copied = deepCopy(origin);
+            for (int idx : sequence) {
+                rotate(copied, rotateInfo[idx]);
+            }
+            answer = Math.min(answer, getMinRowSum(copied));
+            return;
+        }
+
+        for (int i = 0; i < K; i++) {
+            if (!visited[i]) {
+                visited[i] = true;
+                sequence.add(i);
+                dfs(depth + 1, sequence);
+                sequence.remove(sequence.size() - 1);
+                visited[i] = false;
+            }
+        }
+    }
+
+    // 배열 복사
+    static int[][] deepCopy(int[][] arr) {
+        int[][] newArr = new int[arr.length][arr[0].length];
+        for (int i = 0; i < arr.length; i++) {
+            newArr[i] = arr[i].clone();
+        }
+        return newArr;
+    }
+
+    // 회전 연산
+    static void rotate(int[][] arr, int[] op) {
+        int r = op[0] - 1;
+        int c = op[1] - 1;
+        int s = op[2];
+
+        for (int layer = 1; layer <= s; layer++) {
+            int top = r - layer;
+            int left = c - layer;
+            int bottom = r + layer;
+            int right = c + layer;
+
+            int temp = arr[top][left];
+            // 왼쪽 열을 위로 당김
+            for (int i = top; i < bottom; i++) arr[i][left] = arr[i + 1][left];
+            // 아래쪽 행을 왼쪽으로 당김
+            for (int i = left; i < right; i++) arr[bottom][i] = arr[bottom][i + 1];
+            // 오른쪽 열을 아래로 당김
+            for (int i = bottom; i > top; i--) arr[i][right] = arr[i - 1][right];
+            // 위쪽 행을 오른쪽으로 당김
+            for (int i = right; i > left + 1; i--) arr[top][i] = arr[top][i - 1];
+            arr[top][left + 1] = temp;
+        }
+    }
+
+    // 최솟값 계산
+    static int getMinRowSum(int[][] arr) {
+        int min = Integer.MAX_VALUE;
+        for (int[] row : arr) {
+            int sum = 0;
+            for (int val : row) sum += val;
+            min = Math.min(min, sum);
+        }
+        return min;
+    }
+}


### PR DESCRIPTION
## 🧩 문제 요약

* 크기가 NxM인 배열이 주어지고, K개의 회전 연산 `(r, c, s)`이 주어진다.
* 회전 연산을 **모든 순서에 대해 적용**했을 때, 배열의 **행별 합 중 최소값**을 구하는 문제이다.

## ✅ 알고리즘

* **DFS**를 이용해 회전 연산의 **모든 순열**을 생성
* 각 순열에 대해 배열을 **딥카피**한 뒤, 순서대로 회전 연산을 수행
* 회전 연산은 **각 레이어(겹)를 시계방향으로 한 칸 이동**하는 방식으로 구현

## 🧠 구현 포인트

### 📌 1. dfs(depth, sequence)

* 회전 연산의 순열을 생성하는 함수
* 백트래킹을 통해 방문하지 않은 연산을 차례로 선택하고 깊이 우선 탐색
* 모든 depth가 채워졌을 때 실제 회전 연산을 수행하고 최소값 갱신

### 📌 2. rotate(int\[]\[] arr, int\[] op)

* 중심 좌표 `(r, c)`와 반지름 `s`를 기준으로 시계방향으로 한 겹씩 이동
* 한 겹(layer)의 4방향 테두리를 이동시킨다

#### 예시: (r, c, s) = (3, 4, 2)

* 중심은 (3,4), s=2이면 좌우/상하로 각각 2칸씩 확장된 범위를 회전하므로, (3±2, 4±2) → (1,2) \~ (5,6)까지의 영역을 포함한 총 5행 × 5열, 즉 5x5 크기의 회전 대상이 생김
* 회전 테두리는 (1,2) \~ (5,6)
* 2겹의 테두리를 각각 회전함

#### 방향별 이동 수식 예시

1. **시작점 저장**

```java
int temp = arr[top][left];
```

* 첫 위치의 값을 저장해 마지막에 채워 넣음

2. **왼쪽 열 위로 이동**

```java
for (int i = top; i < bottom; i++) arr[i][left] = arr[i + 1][left];
```

* (1,2) ← (2,2), (2,2) ← (3,2), ...

3. **아래 행 왼쪽으로 이동**

```java
for (int i = left; i < right; i++) arr[bottom][i] = arr[bottom][i + 1];
```

* (5,2) ← (5,3), (5,3) ← (5,4), ...

4. **오른쪽 열 아래로 이동**

```java
for (int i = bottom; i > top; i--) arr[i][right] = arr[i - 1][right];
```

* (5,6) ← (4,6), (4,6) ← (3,6), ...

5. **위 행 오른쪽으로 이동 + temp 삽입**

```java
for (int i = right; i > left + 1; i--) arr[top][i] = arr[top][i - 1];
arr[top][left + 1] = temp;
```

* (1,6) ← (1,5), (1,5) ← (1,4), ..., 마지막에 (1,3) ← temp

### 📌 3. deepCopy(int\[]\[] arr)

* 2차원 배열을 복사해서 원본 손상 없이 회전 연산을 수행하도록 함

### 📌 4. getMinRowSum(int\[]\[] arr)

* 회전이 끝난 배열에서 각 행의 합을 구하고 그 중 최솟값을 반환

## 💡 회고

* 테두리를 한 칸씩 회전시키는 방식에 익숙하지 않았다면 실수하기 쉬운 문제였다.
* 회전 순서가 결과에 영향을 주기 때문에 모든 순열을 고려해야 했고, 순열 + 구현이 잘 조합된 문제였다.
* `deepCopy()`를 통해 원본 배열을 안전하게 유지하는 것이 핵심이었다.
* 회전 연산이 겹 단위로 적용된다는 사실을 놓치지 않아야 한다.
* 지피티 없이 못 살겠다

## 📝 참고

* 문제 링크: [https://www.acmicpc.net/problem/17406](https://www.acmicpc.net/problem/17406)
