### PR TITLE
등굣길 문제 풀이

### DIFF
--- a/session1/src/week5/chaeyeon/dp/gayeong/School.java
+++ b/session1/src/week5/chaeyeon/dp/gayeong/School.java
@@ -1,0 +1,29 @@
+package week5.chaeyeon.dp.gayeong;
+
+public class School {
+    public int solution(int m, int n, int[][] puddles) {
+        int MOD = 1_000_000_007;
+        int[][] dp = new int[n + 1][m + 1];
+
+        for (int[] puddle : puddles) {
+            int x = puddle[0];
+            int y = puddle[1];
+            dp[y][x] = -1;
+        }
+
+        dp[1][1] = 1;
+
+        for (int y = 1; y <= n; y++) {
+            for (int x = 1; x <= m; x++) {
+                if (dp[y][x] == -1) {
+                    dp[y][x] = 0;
+                    continue;
+                }
+                if (x > 1) dp[y][x] = (dp[y][x] + dp[y][x - 1]) % MOD;
+                if (y > 1) dp[y][x] = (dp[y][x] + dp[y - 1][x]) % MOD;
+            }
+        }
+
+        return dp[n][m];
+    }
+}


### PR DESCRIPTION
## 고민
최단 경로라서 dfs, bfs로 풀 수도 있는데 왜 dp를 사용해야 할까?
> 바로 dfs, bfs 는 모든 경로를 탐색하기 때문에 시간초과가 발생한다.

- dp[y][x]는 (1,1)부터 (x,y)까지 가는 최단 경로 수
- puddles는 (x, y) 좌표 기준이므로 dp[y][x]로 접근 (행렬로 접근하므로 x, y좌표가 뒤바뀜)
### 점화식
현재 위치 (x,y)에 도달하는 방법은
1. 위쪽 (x, y - 1)에서 내려오거나
2. 왼쪽 (x - 1, y)에서 오른쪽으로 온 두 가지뿐
> dp[y][x] = dp[y - 1][x] + dp[y][x - 1]

## 새로 알게된 점
java 7부터 도입된 것으로 _를 사용하여 숫자 가독성을 높일 수 있다.
``` java
int a = 1000000007;
int b = 1_000_000_007;
```