### PR TITLE
체육복 문제 풀이

### DIFF
--- a/session1/src/week6/greedy/gayeong/Sports.java
+++ b/session1/src/week6/greedy/gayeong/Sports.java
@@ -1,0 +1,79 @@
+package week6.greedy.gayeong;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Scanner;
+
+public class Sports {
+
+    public int solution(int n, int[] lost, int[] reserve) {
+
+        Arrays.sort(lost);
+        Arrays.sort(reserve);
+        ArrayList<Integer> lostList = new ArrayList<>();
+        ArrayList<Integer> reserveList = new ArrayList<>();
+
+        //1. 도난 당했으면서, 여분도 없는 학생
+        for (int student : lost) {
+            if (!contains(reserve, student)) {
+                lostList.add(student);
+            }
+        }
+        //2. 도난 당했으나 여분이 있는 학생은 reserve에서 빼기
+        for (int student : reserve) {
+            if (!contains(lost, student)) {
+                reserveList.add(student);
+            }
+        }
+
+        int answer = n - lostList.size();
+
+        for (int student : lostList) {
+            int borrow = -1;
+            for (int clothes : reserveList) {
+                if (Math.abs(clothes - student) == 1) {
+                    borrow = clothes;
+                    break;
+                }
+            }
+
+            if (borrow != -1) {
+                answer++;
+                reserveList.remove(Integer.valueOf(borrow));
+            }
+        }
+
+        return answer;
+    }
+
+    private boolean contains(int[] arr, int value) {
+        for (int i : arr) {
+            if (value == i) return true;
+        }
+        return false;
+    }
+
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+
+        int n = sc.nextInt();
+
+        int lostCount = sc.nextInt();
+        int[] lost = new int[lostCount];
+        for (int i = 0; i < lostCount; i++) {
+            lost[i] = sc.nextInt();
+        }
+
+        int reserveCount = sc.nextInt();
+        int[] reserve = new int[reserveCount];
+        for (int i = 0; i < reserveCount; i++) {
+            reserve[i] = sc.nextInt();
+        }
+
+        sc.close();
+
+        Sports sports = new Sports();
+        int result = sports.solution(n, lost, reserve);
+        System.out.println(result);
+    }
+}


### PR DESCRIPTION
## 아이디어
인접한 번호의 학생에게만 체육복을 빌려줄 수 있으므로, 잃어버린 학생과 여분이 있는 학생 배열을 오름차순 정렬 후 그리디 방식으로 선형 탐색하여 해를 구한다.

## 문제 풀이
1. lostList에 체육복을 잃어버렸지만 여분은 없는 학생을 추가한다.
2. reserveList에 여분은 있지만 체육복을 잃어버리지 않은 학생을 추가한다.
3. lostList를 순회하며, 인접 번호가 reserveList에 있으면 answer를 1 증가시키고 해당 여분 번호를 리스트에서 제거한다.

## 알게 된 점
- `List.remove(int index)`와 `List.remove(Object o)`의 오버로딩 차이로, `reserveList.remove(Integer.valueOf(x))`처럼 `Integer`를 명시해야 **값 기반 삭제**가 가능하다는 것을 배웠다.
